### PR TITLE
adds aerosol reaction to golem death

### DIFF
--- a/code/obj/critter/misc.dm
+++ b/code/obj/critter/misc.dm
@@ -686,7 +686,7 @@
 		smoke_reaction(src.reagents, 12, T)
 		classic_smoke_reaction(temporary_holder, 10, T)
 		invisibility = 100
-		sleep(5 SECONDS)
+		SPAWN_DBG(5 SECONDS)
 			qdel(src)
 
 /obj/critter/townguard

--- a/code/obj/critter/misc.dm
+++ b/code/obj/critter/misc.dm
@@ -680,10 +680,13 @@
 		..()
 
 		src.visible_message("<span class='combat'><b>[src]</b> bursts into a puff of smoke!</span>")
-		var/datum/chemical_reaction/smoke/thesmoke = new
-		thesmoke.on_reaction(src.reagents, 12)
+		var/datum/reagents/temporary_holder = new/datum/reagents(1000)
+		src.reagents.copy_to(temporary_holder)
+		var/turf/T = get_turf(src)
+		smoke_reaction(src.reagents, 12, T)
+		classic_smoke_reaction(temporary_holder, 10, T)
 		invisibility = 100
-		SPAWN_DBG(5 SECONDS)
+		sleep(5 SECONDS)
 			qdel(src)
 
 /obj/critter/townguard

--- a/code/obj/critter/misc.dm
+++ b/code/obj/critter/misc.dm
@@ -683,7 +683,7 @@
 		var/datum/reagents/temporary_holder = new/datum/reagents(1000)
 		src.reagents.copy_to(temporary_holder)
 		var/turf/T = get_turf(src)
-		smoke_reaction(src.reagents, 12, T)
+		smoke_reaction(src.reagents, 5, T)
 		classic_smoke_reaction(temporary_holder, 10, T)
 		invisibility = 100
 		SPAWN_DBG(5 SECONDS)


### PR DESCRIPTION
This copies the contents of a golem to a temporary container on death so that both the current smoke reaction and an additional small aerosol reaction occur.

## Why's this needed?
The idea is making golems of disease reagents and several of the scarier poisons dangerous to fight at close-range, so that more exotic golems aren't easily handled by kiting with a basic melee weapon and walking out of the smoke cloud. Hopefully this encourages wizards to get creative with their golem chem choices.

## Changelog
(u)Lurkey:
(+)Golem on-death reaction now includes aerosol in addition to smoke.
